### PR TITLE
Feature: launch lti programmatically

### DIFF
--- a/support/lti.js
+++ b/support/lti.js
@@ -298,7 +298,5 @@ Cypress.Commands.add('getLtiLaunchUrl', options => {
             registration,
             claims
         }
-    }).then(response => {
-        return response.body.link;
-    });
+    }).then(response => response.body.link);
 });

--- a/support/lti.js
+++ b/support/lti.js
@@ -267,3 +267,40 @@ Cypress.Commands.add('ltiLaunchViaTool', options => {
             });
         });
 });
+
+/**
+ * Returns the launch URL of an LTI application
+ *
+ * The command uses the API of `demo-lti1p3`
+ * (https://github.com/oat-sa/demo-lti1p3/blob/master/doc/api.md#ltiresourcelinkrequest-launch-generation-endpoint)
+ *
+ * @example
+ * cy.ltiLaunchViaTool({
+ *   toolUrl: 'http://demo.lti.app/api/launch',
+ *   authToken: 'q4s7fv80n9eq5z5f7fgs',
+ *   registration: 'default',
+ *   ltiResourceId: '0d3d8b41-7af1-4ad1-9fc0-5f9b1db23287'
+ * });
+ *
+ * @param {ltiOptions} options
+ */
+Cypress.Commands.add('getLtiLaunchUrl', options => {
+    const toolUrl = options.toolUrl;
+    const authToken = options.authToken;
+    const registration = options.registration;
+    const claims = prepareLtiClaims(options);
+
+    cy.request({
+        method: 'POST',
+        url: `${toolUrl}/api/platform/messages/ltiResourceLinkRequest/launch`,
+        auth: {
+            bearer: authToken
+        },
+        body: {
+            registration,
+            claims
+        }
+    }).then(response => {
+        return response.body.link;
+    });
+});

--- a/support/lti.js
+++ b/support/lti.js
@@ -285,9 +285,7 @@ Cypress.Commands.add('ltiLaunchViaTool', options => {
  * @param {ltiOptions} options
  */
 Cypress.Commands.add('getLtiLaunchUrl', options => {
-    const toolUrl = options.toolUrl;
-    const authToken = options.authToken;
-    const registration = options.registration;
+    const { toolUrl, authToken, registration } = options;
     const claims = prepareLtiClaims(options);
 
     cy.request({


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-1223

# Description

Added a command `getLtiLaunchUrl` to launch an LTI app programmatically. The command expects:

- `ltitoolUrl`
- `authToken`
-  Other lti config params

# How to test?

- Please check this PR: https://github.com/oat-sa/tao-proctoring-fe/pull/77

# Related PRs

- [ ] https://github.com/oat-sa/tao-proctoring-fe/pull/77