### PR TITLE
Breaking: change plugins exports

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ The cloned repo should now be symlinked into your project's `node_modules`, for 
 
 <a name="#scripts"></a>
 
-The following are examples of npm scripts you could set up in your local project. This takes advantage of Cypress configuration being [overridable by environment variables](https://docs.cypress.io/guides/guides/environment-variables.html) prefixed with `CYPRESS_` and by `--env` flags. This can be useful in CI.
+The following are **examples** of npm scripts you could set up in your local project. This takes advantage of Cypress configuration being [overridable by environment variables](https://docs.cypress.io/guides/guides/environment-variables.html) prefixed with `CYPRESS_` and by `--env` flags. This can be useful in CI.
 
 Open Cypress interface
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ After running `npm run cy:open` for the first time, `cypress.json` and the `cypr
 |-- cypress/
   |-- fixtures/         # Static fixtures for your tests
   |-- integration/      # Example tests / your tests
-  |-- plugins/          #
+  |-- plugins/          # Local plugins and plugins init file
   |-- screenshots/      # Output of failed tests
   |-- support/          # The place for local support commands
 </pre>
@@ -31,6 +31,10 @@ After running `npm run cy:open` for the first time, `cypress.json` and the `cypr
 ## Create environment config(s)
 
 Create a file `cypress.env.json` containing values specific to your test environment. You may want more than one version of this file if you wish to test on several envs (e.g. local / remote).
+
+The values within this object can be accessed in your tests via `Cypress.env('keyName')`. Nested values are supported too.
+
+### More flexible environment configs
 
 Alternatively, you can use a different env file by configuring, in `cypress.json`:
 
@@ -42,6 +46,15 @@ Alternatively, you can use a different env file by configuring, in `cypress.json
 }
 ```
 
-This opens up the possibility to change environment configs at launch time via the CLI (see [Scripts](./development.md#scripts)).
+The use of the above `env.configFile` setting requires you to run the `extendConfig` function on the Cypress config, in your local `plugins/index.js`:
 
-The values within this object can be accessed in your tests via `Cypress.env('keyName')`. Nested values are supported too.
+```js
+const extendConfig = require('@oat-sa/e2e-runner/plugins/extendConfig.js');
+
+module.exports = (on, config) => {
+    return extendConfig(config);
+};
+
+```
+
+This opens up the possibility to change environment configs at launch time via the CLI (see [Scripts](./development.md#scripts)).

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ After running `npm run cy:open` for the first time, `cypress.json` and the `cypr
 |-- cypress/
   |-- fixtures/         # Static fixtures for your tests
   |-- integration/      # Example tests / your tests
-  |-- plugins/          # Local plugins and plugins init file
+  |-- plugins/          # The place for local plugins
   |-- screenshots/      # Output of failed tests
   |-- support/          # The place for local support commands
 </pre>

--- a/docs/plugins_commands.md
+++ b/docs/plugins_commands.md
@@ -4,20 +4,14 @@ Plugins and commands make up over 90% of what is provided by `e2e-runner`.
 
 ## Plugins
 
-The recommendation is to install all needed plugins as dependencies of `e2e-runner` only. Then, edit your local `cypress.json` to point to the `plugins` folder of `e2e-runner`:
+Shared plugins can be added to `e2e-runner`, either by writing them here, or installing as dependencies. The idea is to create a file in `e2e-runner/plugins/` which exports the functionality you want to expose.
 
-```json
-// cypress.json
-{
-  "pluginsFile": "../node_modules/@oat-sa/e2e-runner/plugins",
-}
-```
-
-This plugin entry point also handles extending the main config, so it's advantageous to stick with this centralised implementation rather than creating a local plugins function.
+Projects can then import the plugins they need and compose them in their local `pluginsFile`.
 
 ### Bundled plugins
 
 - [cypress-plugin-snapshots](https://github.com/meinaart/cypress-plugin-snapshots) - takes visual snapshots for comparison with subsequent test runs
+- [cypress-file-upload](https://github.com/abramenal/cypress-file-upload) - helps with file uploads in the browser
 
 ## Commands
 

--- a/docs/plugins_commands.md
+++ b/docs/plugins_commands.md
@@ -11,7 +11,7 @@ Projects can then import the plugins they need and compose them in their local `
 ### Bundled plugins
 
 - [cypress-plugin-snapshots](https://github.com/meinaart/cypress-plugin-snapshots) - takes visual snapshots for comparison with subsequent test runs
-- [cypress-file-upload](https://github.com/abramenal/cypress-file-upload) - helps with file uploads in the browser
+- extendConfig - Extends Cypress config file with environment variables
 
 ## Commands
 

--- a/plugins/extendConfig.js
+++ b/plugins/extendConfig.js
@@ -13,20 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019-21 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
-
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/plugins-guide
-// ***********************************************************
-
-const { initPlugin: initSnapshotPlugin } = require('cypress-plugin-snapshots/plugin');
 
 const fs = require('fs-extra');
 const path = require('path');
@@ -43,19 +31,12 @@ function getConfigurationByFile(envConfigFile) {
 }
 
 /**
- * Responsible for init of third-party plugins
- * Also extends config object
- * This function is called when a project is opened or re-opened (e.g. due to the project's config changing)
- *
- * @type {Cypress.PluginConfig}
- * @param {function} on used to hook into various events Cypress emits
- * @param {Object} config the resolved Cypress config
+ * Extends Cypress env config with data from file
+ * specified on env.configFile key, if exists
+ * @param {Object} config - Cypress config file
+ * @returns {Object} - Extended Cypress config
  */
-module.exports = (on, config) => {
-    // plugin inits
-    initSnapshotPlugin(on, config);
-
-    // extend main config with env config, if env.configFile key exists
+function extendConfig(config) {
     if (config && config.env && config.env.configFile) {
         return getConfigurationByFile(config.env.configFile).then(configJson => {
             Object.assign(config.env, configJson);
@@ -63,4 +44,6 @@ module.exports = (on, config) => {
         });
     }
     return config;
-};
+}
+
+module.exports = extendConfig;

--- a/plugins/snapshots.js
+++ b/plugins/snapshots.js
@@ -1,0 +1,24 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 21 (original work) Open Assessment Technologies SA ;
+ */
+
+const { initPlugin } = require('cypress-plugin-snapshots/plugin');
+
+/**
+ * @exports {Function} the plugin init function for cypress-plugin-snapshots
+ */
+module.exports = initPlugin;


### PR DESCRIPTION
For better flexibility between central and local plugins, let's export the `extendConfig` and the `cypress-plugin-snapshots` config functions separately, and compose them in a pluginsFile in our local projects.

TODO:
- [x] documentation change
- [ ] should the `snapshots.js` file be skipped? If the plugin can be imported directly by the local project...

You can test this change in your local project by defining a local `pluginsFile`:
```
{
  "pluginsFile": "cypress/plugins",
}
```
and within it, this kind of init function:
```js
const initSnapshotPlugin = require('@oat-sa/e2e-runner/plugins/snapshots.js');
const extendConfig = require('@oat-sa/e2e-runner/plugins/extendConfig.js');

module.exports = (on, config) => {
    initSnapshotPlugin(on, config);
    return extendConfig(config);
};
```
Deliver users can test directly via the PR: https://github.com/oat-sa/tao-deliver-fe/pull/18