### PR TITLE
feature/TR-1080/Allow setting the baseUrl from the env

### DIFF
--- a/plugins/extendConfig.js
+++ b/plugins/extendConfig.js
@@ -40,6 +40,9 @@ function extendConfig(config) {
     if (config && config.env && config.env.configFile) {
         return getConfigurationByFile(config.env.configFile).then(configJson => {
             Object.assign(config.env, configJson);
+            if (config.env.baseUrl) {
+                config.baseUrl = config.env.baseUrl;
+            }
             return config;
         });
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1080

The `baseUrl` may be dependent on the local environment. Having it set exclusively from `cypress.json` may be cumbersome as this file should be static.

The proposed solution is to allow setting this value from an env file instead, and forward it to the main config from the plugins loader.

To test it:
- make sure the `baseUrl` is removed from the `cypress.json` file
- set this value in you env file
- run a test and check that `cy.visit()` or `cy.request()` are loading the expected domain.

Note: you may have to refactor your plugins loader following the instruction given in this previous PR: #10