### PR TITLE
fix: cast ltiResourceId to empty string

### DIFF
--- a/support/lti.js
+++ b/support/lti.js
@@ -134,8 +134,7 @@ function getLtiOptions(options) {
     );
 
     refinedOptions.ltiLaunchUrl =
-        refinedOptions.ltiLaunchUrl ||
-        `${refinedOptions.ltiBaseLaunchUrl}${refinedOptions.ltiResourceId ? refinedOptions.ltiResourceId : ''}`;
+        refinedOptions.ltiLaunchUrl || `${refinedOptions.ltiBaseLaunchUrl}${refinedOptions.ltiResourceId || ''}`;
 
     return refinedOptions;
 }

--- a/support/lti.js
+++ b/support/lti.js
@@ -134,7 +134,8 @@ function getLtiOptions(options) {
     );
 
     refinedOptions.ltiLaunchUrl =
-        refinedOptions.ltiLaunchUrl || `${refinedOptions.ltiBaseLaunchUrl}${refinedOptions.ltiResourceId}`;
+        refinedOptions.ltiLaunchUrl ||
+        `${refinedOptions.ltiBaseLaunchUrl}${refinedOptions.ltiResourceId ? refinedOptions.ltiResourceId : ''}`;
 
     return refinedOptions;
 }
@@ -145,15 +146,7 @@ function getLtiOptions(options) {
  * @returns {Object} all claims, JSON format
  */
 function prepareLtiClaims(options) {
-    const {
-        ltiReturnUrl,
-        ltiLocale,
-        ltiContext,
-        nrps,
-        nrpsMembershipsUrl,
-        ltiRole,
-        ltiCustom
-    } = options;
+    const { ltiReturnUrl, ltiLocale, ltiContext, nrps, nrpsMembershipsUrl, ltiRole, ltiCustom } = options;
     const claims = {};
     const launchPresentationClaims = {};
 


### PR DESCRIPTION
related (not really, but found the issue during making review of that task) https://oat-sa.atlassian.net/browse/TRN-715

### Description

When `ltiResourceId` is unset for some reason (misconfiguration, or typo in *env.json file of consumer application), link is generated with text `undefined` instead of empty, that results in misleading state of test launch with error like `OAuth signature is invalid`

### How to test

With deliver app try to launch local test with absent resourceId