### PR TITLE
fix: lti launch button renamed

### DIFF
--- a/support/lti.js
+++ b/support/lti.js
@@ -279,7 +279,7 @@ Cypress.Commands.add('ltiLaunchViaTool', options => {
             // Generate launch link
             cy.contains('Generate').click();
 
-            cy.contains('.btn', 'Launch LtiResourceLinkRequest').then($el => {
+            cy.contains('.btn', 'Launch').then($el => {
                 // link has target="_blank" which we don't want to obey
                 const ltiLink = $el.get(0).getAttribute('href');
                 cy.visit(ltiLink);


### PR DESCRIPTION
[LTI launch button](https://devkit-oat-dev.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=DeliverRegistration_development&user_list=chewbacca&custom_user_id=2023-03-15_10-06-52&custom_user_name=2023-03-15_10-06-52&custom_user_locale=nb-NO&launch_url=https://testrunner-oat-dev.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/2c5684ab2cf7&claims={%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20[%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20],%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/custom%22:%20{%0D%0A%20%20%20%20%20%20%20%20%22proctoringSettings.enableMonitoring%22:%20%22false%22,%0D%0A%20%20%20%20%20%20%20%20%22proctoringSettings.requireProctorAuthorization%22:%20%22false%22%0D%0A%20%20%20%20},%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/context%22:%20{%0D%0A%20%20%20%20%20%20%20%20%22id%22:%20%22ok-125-ok%22%0D%0A%20%20%20%20}%0D%0A}#
) was renamed
![Screenshot_14](https://github.com/oat-sa/e2e-runner/assets/38751932/ffa62f53-0491-4e83-b20a-3b2cf7d5ba34)

Can be tested with https://github.com/oat-sa/tao-deliver-fe/pull/787 : `npm run cy:open`, choose any test for OAT-Dev

